### PR TITLE
PostgreSQL integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Each entry consists of the following:
 | `name`    | :heavy_check_mark: | Name of the auth option like ldap, user_table |
 | `options` | :heavy_check_mark: | Dict of options for the auth method           |
 
-## Example
+#### Example
 
 ```yaml
 sympa_auth:
@@ -90,7 +90,7 @@ Each list entry contains the following:
 | `path`  | :heavy_check_mark: | Path of the category  |
 | `title` | :heavy_check_mark: | Title of the category |
 
-## Example
+#### Example
 
 ```yaml
 sympa_topics:
@@ -99,6 +99,13 @@ title: Art
 - path: art/expressionism
 title: Expressionism
 ```
+
+### Database manager
+
+| Name                       | Required/Default   | Description                                                                               |
+|:---------------------------|:------------------:|:------------------------------------------------------------------------------------------|
+| `sympa_db_type`            | `mysql`            | Choice of database manager. `mysql` or `PostgreSQL`. Other sympa options are not managed. |
+| `sympa_install_db_package` | `False`            | Whether the db manager is installed previously (`False`) or the role installs it (`True`) |
 
 ### Sympa Variables
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
 # sympa
-This is an Ansible role which sets up a sympa
+
+This is an Ansible role which sets up a [Sympa](https://sympa.org) mailing list manager.
 
 
 ## Requirements
 
-Debian or Ubuntu with a webserver that serves the sympa web app and a mysql database for it.
+Debian stretch or Ubuntu server. MySQL/MariaDB or PostgreSQL database options. Database manager can be previously installed in the host (default) or optionnally installed by the role itself. Webserver for Sympa should be configured elsewhere. 
 
 
 ## Role Variables
 
-For the full documentation see https://sympa-community.github.io/, this was tested with Sympa Version 6.2.16
+For the full documentation see https://sympa-community.github.io/, this role was tested with Sympa Version 6.2.16 (Debian stretch sympa package).
 
 ### List Templates
 `sympa_template_lists` is a list of templates to be defined.
@@ -104,7 +105,7 @@ title: Expressionism
 
 | Name                       | Required/Default   | Description                                                                               |
 |:---------------------------|:------------------:|:------------------------------------------------------------------------------------------|
-| `sympa_db_type`            | `mysql`            | Choice of database manager. `mysql` or `PostgreSQL`. Other sympa options are not managed. |
+| `sympa_db_type`            | `mysql`            | Choice of database manager. `MySQL` or `PostgreSQL`. `mysql` and `Pg` values are acceptable, but deprecated. Other database options are not managed. |
 | `sympa_install_db_package` | `False`            | Whether the db manager is installed previously (`False`) or the role installs it (`True`) |
 
 ### Sympa Variables
@@ -214,3 +215,4 @@ This work is licensed under a [Creative Commons Attribution-ShareAlike 4.0 Inter
 ## Author Information
 
 * [Fritz Otlinghaus (Scriptkiddi)](https://github.com/Scriptkiddi) _fritz.otlinghaus@stuvus.uni-stuttgart.de_
+* [UdelaR Interior](https://github.com/UdelaRInterior) contributions

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,7 @@
 ---
+## Sympa Ansible role default variables
+
+sympa_domain: "{{ ansible_fqdn }}"
 sympa_show_default_templates: false
 sympa_template_lists: []
 ## Define the following variables for ldap alias manager
@@ -14,7 +17,7 @@ sympa_db_type: mysql             # mysql or PostgreSQL
 sympa_install_db_package: False  # yes for this role to install mysql or postgres, no if installed elsewhere 
 sympa_db_name: sympa
 sympa_db_host: localhost
-sympa_db_port: 3306
+sympa_db_port: "{{ 5432 if sympa_db_type == 'PostgreSQL' else 3306 }}"
 sympa_db_user: sympa
 sympa_lang: en
 sympa_auth:
@@ -119,3 +122,19 @@ sympa_ldap_force_canonical_email: 1
 sympa_review_page_size: 25
 sympa_webserver_type: Other                        # 'Other' or 'Apache 2'
 sympa_web_page_title: Mailing lists service
+
+sympa_apache2_configure: false
+sympa_www_domain: '{{ sympa_domain }}'
+sympa_server_admin: 'listmaster@{{ sympa_domain }}'
+sympa_wwsympa_url: 'https://{{ sympa_www_domain }}/{{ sympa_script_alias }}'
+sympa_script_alias: wws
+sympa_static_alias: static-sympa
+
+## SSL webserver certificates
+sympa_ssl_cert_file:     /etc/ssl/certs/ssl-cert-snakeoil.pem
+sympa_ssl_cert_key_file: /etc/ssl/private/ssl-cert-snakeoil.key
+## It's worthful to install certbot and define
+# sympa_ssl_cert_file:     /etc/letsencrypt/live/{{ sympa_www_domain }}/cert.pem
+# sympa_ssl_cert_key_file: /etc/letsencrypt/live/{{ sympa_www_domain }}/privkey.pem
+
+...

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,7 +11,7 @@ sympa_template_lists: []
 
 ## Database variables
 sympa_db_type: mysql             # mysql or PostgreSQL
-sympa_install_db_package: false  # yes for this role to install mysql or postgres, no if installed elsewhere 
+sympa_install_db_package: False  # yes for this role to install mysql or postgres, no if installed elsewhere 
 sympa_db_name: sympa
 sympa_db_host: localhost
 sympa_db_port: 3306

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,8 +10,8 @@ sympa_template_lists: []
 #  bouncequeue_transport: sympabounce
 
 ## Database variables
-sympa_db_type: mysql             # mysql or pgsql
-sympa_install_db_package: false  # yes for this role to install mysql or postgres, no if installed elsewhere / TODO: not yet working for MySQL
+sympa_db_type: mysql             # mysql or PostgreSQL
+sympa_install_db_package: false  # yes for this role to install mysql or postgres, no if installed elsewhere 
 sympa_db_name: sympa
 sympa_db_host: localhost
 sympa_db_port: 3306

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,10 @@ sympa_template_lists: []
 #  ssl: true
 #  queue_transport: sympa
 #  bouncequeue_transport: sympabounce
+
+## Database variables
+sympa_db_type: mysql             # mysql or pgsql
+sympa_install_db_package: false  # yes for this role to install mysql or postgres, no if installed elsewhere / TODO: not yet working for MySQL
 sympa_db_name: sympa
 sympa_db_host: localhost
 sympa_db_port: 3306
@@ -113,4 +117,5 @@ sympa_default_home: home
 sympa_edit_list: owner
 sympa_ldap_force_canonical_email: 1
 sympa_review_page_size: 25
+sympa_webserver_type: Other                        # 'Other' or 'Apache 2'
 sympa_web_page_title: Mailing lists service

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,8 +13,8 @@ sympa_template_lists: []
 #  bouncequeue_transport: sympabounce
 
 ## Database variables
-sympa_db_type: mysql             # mysql or PostgreSQL
-sympa_install_db_package: False  # yes for this role to install mysql or postgres, no if installed elsewhere 
+sympa_db_type: mysql             #'MySQL' or 'mysql'. or 'PostgreSQL' or 'Pg'. 'mysql' and 'Pg' values are deprecated
+sympa_install_db_package: False  # 'True' for this role to install mysql or postgresql package, 'False' if installed elsewhere 
 sympa_db_name: sympa
 sympa_db_host: localhost
 sympa_db_port: "{{ 5432 if sympa_db_type == 'PostgreSQL' else 3306 }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,8 +25,6 @@
   loop:
       ## set the database type
   - { name: 'sympa', question: 'sympa/database-type', value: '{{ sympa_db_type }}' , vtype: select }
-      ## Configure the database at sympa installation with dbconfig
-  - { name: 'sympa', question: 'sympa/dbconfig-install', value: 'true' , vtype: boolean }
       ## Set the sympa database name
   - { name: 'sympa', question: 'sympa/db/dbname', value: '{{ sympa_db_name }}' , vtype: string }
       ## Set the sympa database user

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,10 +11,12 @@
 - name: MySQL/MariaDB configuration
   include_tasks: mysql.yml
   when: sympa_db_type | lower == 'mysql'
+  tags: mysql
 
 - name: PostgreSQL configuration
   include_tasks: postgresql.yml
   when: sympa_db_type | lower == 'postgresql'
+  tags: postgresql
 
 - name: Set debconf options for sympa
   debconf:
@@ -25,6 +27,8 @@
   loop:
       ## set the database type
   - { name: 'sympa', question: 'sympa/database-type', value: '{{ sympa_db_type }}' , vtype: select }
+      ## This Ansible role configures the database, not dbconfig at sympa package installation 
+  - { name: 'sympa', question: 'sympa/dbconfig-install', value: 'false' , vtype: boolean }
       ## Set the sympa database name
   - { name: 'sympa', question: 'sympa/db/dbname', value: '{{ sympa_db_name }}' , vtype: string }
       ## Set the sympa database user
@@ -54,6 +58,7 @@
     name:
       - sympa
       - fcgiwrap
+    state: latest
 
 - name: Fix permissions
   file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,13 +1,20 @@
 ---
 ## Sympa configuration main tasks file
 
+- name: Check that "debconf" and "debconf-utils" are installed
+  apt:
+    name:
+    - debconf
+    - debconf-utils
+    state: latest
+
 - name: MySQL/MariaDB configuration
   include_tasks: mysql.yml
-  when: sympa_db_type == 'mysql'
+  when: sympa_db_type | lower == 'mysql'
 
 - name: PostgreSQL configuration
   include_tasks: postgresql.yml
-  when: sympa_db_type == 'PostgreSQL'
+  when: sympa_db_type | lower == 'postgresql'
 
 - name: Set debconf options for sympa
   debconf:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,12 +10,12 @@
 
 - name: MySQL/MariaDB configuration
   include_tasks: mysql.yml
-  when: sympa_db_type | lower == 'mysql'
+  when: sympa_db_type == 'MySQL' or sympa_db_type == 'mysql'
   tags: mysql
 
 - name: PostgreSQL configuration
   include_tasks: postgresql.yml
-  when: sympa_db_type | lower == 'postgresql'
+  when: sympa_db_type == 'PostgreSQL' or sympa_db_type == 'Pg'
   tags: postgresql
 
 - name: Set debconf options for sympa

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,7 +7,7 @@
 
 - name: PostgreSQL configuration
   include_tasks: postgresql.yml
-  when: sympa_db_type == 'pgsql'
+  when: sympa_db_type == 'PostgreSQL'
 
 - name: Set debconf options for sympa
   debconf:
@@ -16,9 +16,19 @@
     value: "{{ item.value }}"
     vtype: "{{ item.vtype }}"
   loop:
+      ## set the database type
   - { name: 'sympa', question: 'sympa/database-type', value: '{{ sympa_db_type }}' , vtype: select }
+      ## Configure the database at sympa installation with dbconfig
   - { name: 'sympa', question: 'sympa/dbconfig-install', value: 'true' , vtype: boolean }
+      ## Set the sympa database name
+  - { name: 'sympa', question: 'sympa/db/dbname', value: '{{ sympa_db_name }}' , vtype: string }
+      ## Set the sympa database user
+  - { name: 'sympa', question: 'sympa/db/app-user', value: '{{ sympa_db_user }}' , vtype: string }
+      ## Use the localhost for database (and not a distant host to define)
+  - { name: 'sympa', question: 'sympa/remote/host', value: 'localhost' , vtype: select }
+      ## Set the webserver type
   - { name: 'sympa', question: 'wwsympa/webserver_type', value: '{{ sympa_webserver_type }}' , vtype: select }
+
 
 - name: Create sympa dir
   file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,36 +1,24 @@
-- name: Set database to mysql
+---
+## Sympa configuration main tasks file
+
+- name: MySQL/MariaDB configuration
+  include_tasks: mysql.yml
+  when: sympa_db_type == 'mysql'
+
+- name: PostgreSQL configuration
+  include_tasks: postgresql.yml
+  when: sympa_db_type == 'pgsql'
+
+- name: Set debconf options for sympa
   debconf:
-    name: sympa
-    question: sympa/database-type
-    value: mysql
-    vtype: select
-
-- name: Set webserver to other
-  debconf:
-    name: sympa
-    question: wwsympa/webserver_type
-    value: Other
-    vtype: select
-
-- name: "Set dbconfig-install to no"
-  debconf:
-    name: sympa
-    question: sympa/dbconfig-install
-    value: no
-    vtype: boolean
-  changed_when: false
-
-- name: Create a new database with name '{{ sympa_db_name }}'
-  mysql_db:
-    name: "{{ sympa_db_name }}"
-    encoding: utf8
-
-- name: Create DB user '{{ sympa_db_user }}'
-  mysql_user:
-    name: "{{ sympa_db_user }}"
-    password: "{{ sympa_db_password | mandatory }}"
-    priv: '{{ sympa_db_name }}.*:ALL,GRANT'
-  no_log: True
+    name: "{{ item.name }}"
+    question: "{{ item.question }}"
+    value: "{{ item.value }}"
+    vtype: "{{ item.vtype }}"
+  loop:
+  - { name: 'sympa', question: 'sympa/database-type', value: '{{ sympa_db_type }}' , vtype: select }
+  - { name: 'sympa', question: 'sympa/dbconfig-install', value: 'true' , vtype: boolean }
+  - { name: 'sympa', question: 'wwsympa/webserver_type', value: '{{ sympa_webserver_type }}' , vtype: select }
 
 - name: Create sympa dir
   file:
@@ -173,3 +161,5 @@
     minute: "0"
     hour: "2"
     job: "/usr/lib/sympa/bin/sympa.pl --reload_list_config"
+
+...

--- a/tasks/mysql.yml
+++ b/tasks/mysql.yml
@@ -49,14 +49,4 @@
     priv: '{{ sympa_db_name }}.*:ALL,GRANT'
   no_log: True
 
-- name: Set debconf options for sympa mysql database
-  debconf:
-    name: "{{ item.name }}"
-    question: "{{ item.question }}"
-    value: "{{ item.value }}"
-    vtype: "{{ item.vtype }}"
-  loop:
-      ## For MySQL, we don't use dbconfig at sympa installation, previous settings are enough 
-  - { name: 'sympa', question: 'sympa/dbconfig-install', value: 'false' , vtype: boolean }
-
 ...

--- a/tasks/mysql.yml
+++ b/tasks/mysql.yml
@@ -1,0 +1,53 @@
+---
+## MySQL configuration for sympa
+
+- name: check mysql installation
+  block: 
+  - name: Gather installed packages
+    package_facts:
+      manager: auto
+
+  - name: check if MySQL is installed
+    assert:
+      that: >
+        ansible_facts.packages['default-mysql-server'] is defined or
+        ansible_facts.packages['mysql-server'] is defined or
+        ansible_facts.packages['mariadb-server-10.1'] is defined   
+      ## The last condition could be replaced by a jinja2 json_query filter to match any version 
+      fail_msg: "No MySQL pachage found. We stop, because we can't install sympa without its database. Sorry."
+      success_msg: "MySQL package found. We can continue!"
+  when: not sympa_install_db_package
+
+## TODO: minimal installation of MySQL for sympa. This single task is not enough
+- name: Install MySQL packages 
+  apt: 
+    name: 
+    - default-mysql-server
+    - python-dev
+    - default-libmysqlclient-dev
+    state: present
+  when: sympa_install_db_package
+
+- name: Install pip, if not yet installed
+  apt: 
+    name: python-pip
+    state: present
+
+- name: install mysqlclient pip module, if not yet installed
+  pip: 
+    name: mysqlclient
+    state: present
+
+- name: Create a new database with name '{{ sympa_db_name }}'
+  mysql_db:
+    name: "{{ sympa_db_name }}"
+    encoding: utf8
+
+- name: Create DB user '{{ sympa_db_user }}'
+  mysql_user:
+    name: "{{ sympa_db_user }}"
+    password: "{{ sympa_db_password | mandatory }}"
+    priv: '{{ sympa_db_name }}.*:ALL,GRANT'
+  no_log: True
+
+...

--- a/tasks/mysql.yml
+++ b/tasks/mysql.yml
@@ -1,7 +1,7 @@
 ---
 ## MySQL configuration for sympa
 
-- name: check mysql installation
+- name: check MySQL installation
   block: 
   - name: Gather installed packages
     package_facts:
@@ -18,7 +18,6 @@
       success_msg: "MySQL package found. We can continue!"
   when: not sympa_install_db_package
 
-## TODO: minimal installation of MySQL for sympa. This single task is not enough
 - name: Install MySQL packages 
   apt: 
     name: 

--- a/tasks/mysql.yml
+++ b/tasks/mysql.yml
@@ -1,21 +1,21 @@
 ---
 ## MySQL configuration for sympa
 
-- name: check MySQL installation
+- name: Check MySQL installation
   block: 
   - name: Gather installed packages
     package_facts:
       manager: auto
 
-  - name: check if MySQL is installed
+  - name: Check if mysql server package is installed
     assert:
       that: >
         ansible_facts.packages['default-mysql-server'] is defined or
         ansible_facts.packages['mysql-server'] is defined or
         ansible_facts.packages['mariadb-server-10.1'] is defined   
       ## The last condition could be replaced by a jinja2 json_query filter to match any version 
-      fail_msg: "No MySQL pachage found. We stop, because we can't install sympa without its database. Sorry."
-      success_msg: "MySQL package found. We can continue!"
+      fail_msg: "No mysql package found. We stop, because we can't install sympa without its database. Sorry."
+      success_msg: "mysql package found. We can continue!"
   when: not sympa_install_db_package
 
 - name: Install MySQL packages 

--- a/tasks/mysql.yml
+++ b/tasks/mysql.yml
@@ -49,4 +49,14 @@
     priv: '{{ sympa_db_name }}.*:ALL,GRANT'
   no_log: True
 
+- name: Set debconf options for sympa mysql database
+  debconf:
+    name: "{{ item.name }}"
+    question: "{{ item.question }}"
+    value: "{{ item.value }}"
+    vtype: "{{ item.vtype }}"
+  loop:
+      ## For MySQL, we don't use dbconfig at sympa installation, previous settings are enough 
+  - { name: 'sympa', question: 'sympa/dbconfig-install', value: 'false' , vtype: boolean }
+
 ...

--- a/tasks/postgresql.yml
+++ b/tasks/postgresql.yml
@@ -49,20 +49,15 @@
     password: "{{ sympa_db_password | mandatory }}"
     priv: ALL
     state: present
-  tags: postgresql
+  
 
 ## Debconf keys for sympa database
 
-- name: Set debconf options for sympa postgresql database
+- name: Set password debconf option for Sympa PostgreSQL database
   debconf:
-    name: "{{ item.name }}"
-    question: "{{ item.question }}"
-    value: "{{ item.value }}"
-    vtype: "{{ item.vtype }}"
-  loop:
-      ## set the database user password
-  - { name: 'sympa', question: 'sympa/pgsql/app-pass', value: '{{ sympa_db_password | mandatory }}' , vtype: password }
-      ## For PostgreSQL, we configure the database at sympa installation with dbconfig
-  - { name: 'sympa', question: 'sympa/dbconfig-install', value: 'true' , vtype: boolean }
+    name: sympa
+    question: sympa/pgsql/app-pass
+    value: "{{ sympa_db_password | mandatory }}"
+    vtype: password
 
 ...

--- a/tasks/postgresql.yml
+++ b/tasks/postgresql.yml
@@ -53,10 +53,16 @@
 
 ## Debconf keys for sympa database
 
-- name: Define sympa postgresql database's password through debconf 
+- name: Set debconf options for sympa postgresql database
   debconf:
-    name: sympa
-    question: 'sympa/pgsql/app-pass'
-    value: '{{ sympa_db_password | mandatory }}'
-    vtype: password
+    name: "{{ item.name }}"
+    question: "{{ item.question }}"
+    value: "{{ item.value }}"
+    vtype: "{{ item.vtype }}"
+  loop:
+      ## set the database user password
+  - { name: 'sympa', question: 'sympa/pgsql/app-pass', value: '{{ sympa_db_password | mandatory }}' , vtype: password }
+      ## For PostgreSQL, we configure the database at sympa installation with dbconfig
+  - { name: 'sympa', question: 'sympa/dbconfig-install', value: 'true' , vtype: boolean }
+
 ...

--- a/tasks/postgresql.yml
+++ b/tasks/postgresql.yml
@@ -1,0 +1,4 @@
+---
+## PostgreSQL configuration for sympa
+
+...

--- a/tasks/postgresql.yml
+++ b/tasks/postgresql.yml
@@ -1,4 +1,65 @@
 ---
-## PostgreSQL configuration for sympa
+## PostgreSQL installation and configuration for sympa
 
+- name: check PostgreSQL installation
+  block: 
+  - name: Gather installed packages
+    package_facts:
+      manager: auto
+
+  - name: check if postgres is installed
+    assert:
+      that: ansible_facts.packages['postgresql'] is defined
+      fail_msg: "No PostgreSQL pachage found. We stop, because we can't install sympa without its database. Sorry."
+      success_msg: "PostgreSQL package found. We can continue!"
+  when: not sympa_install_db_package
+
+- name: Install PostgreSQL
+  apt:
+    state: present
+    update_cache: yes
+    cache_valid_time: 3600
+    name:
+      - postgresql
+      - postgresql-contrib
+      - libpq-dev
+      - python-psycopg2
+      - dbconfig-pgsql
+  when: sympa_install_db_package
+  tags: postgresql
+
+- name: Create sympa database
+  become: true
+  become_user: postgres
+  postgresql_db:
+    name: "{{ sympa_db_name }}"
+    encoding: UTF-8
+    lc_collate: es_UY.UTF-8
+    lc_ctype: es_UY.UTF-8
+    template: template0
+    state: present
+  tags: postgresql
+
+- name: Create sympa user with access to the database
+  become: true
+  become_user: postgres
+  postgresql_user:
+    db: "{{ sympa_db_name }}"
+    name: "{{ sympa_db_user }}"
+    password: "{{ sympa_db_password | mandatory }}"
+    priv: ALL
+    state: present
+  tags: postgresql
+
+## Debconf keys for sympa database
+
+- name: Definir opciones debconf de sympa, relativas a la base PostgreSQL
+  debconf:
+    name: "{{ item.name }}"
+    question: "{{ item.question }}"
+    value: "{{ item.value }}"
+    vtype: "{{ item.vtype }}"
+  loop:
+      ## Set the sympa database password
+  - { name: 'sympa', question: 'sympa/pgsql/app-pass', value: '{{ sympa_db_password | mandatory }}' , vtype: password }
 ...

--- a/tasks/postgresql.yml
+++ b/tasks/postgresql.yml
@@ -1,17 +1,17 @@
 ---
 ## PostgreSQL installation and configuration for sympa
 
-- name: check PostgreSQL installation
+- name: Check PostgreSQL installation
   block: 
   - name: Gather installed packages
     package_facts:
       manager: auto
 
-  - name: check if postgres is installed
+  - name: Check if postgresql server package is installed
     assert:
       that: ansible_facts.packages['postgresql'] is defined
-      fail_msg: "No PostgreSQL pachage found. We stop, because we can't install sympa without its database. Sorry."
-      success_msg: "PostgreSQL package found. We can continue!"
+      fail_msg: "No postgresql package found. We stop, because we can't install sympa without its database. Sorry."
+      success_msg: "postgresql package found. We can continue!"
   when: not sympa_install_db_package
 
 - name: Install PostgreSQL
@@ -53,13 +53,10 @@
 
 ## Debconf keys for sympa database
 
-- name: Definir opciones debconf de sympa, relativas a la base PostgreSQL
+- name: Define sympa postgresql database's password through debconf 
   debconf:
-    name: "{{ item.name }}"
-    question: "{{ item.question }}"
-    value: "{{ item.value }}"
-    vtype: "{{ item.vtype }}"
-  loop:
-      ## Set the sympa database password
-  - { name: 'sympa', question: 'sympa/pgsql/app-pass', value: '{{ sympa_db_password | mandatory }}' , vtype: password }
+    name: sympa
+    question: 'sympa/pgsql/app-pass'
+    value: '{{ sympa_db_password | mandatory }}'
+    vtype: password
 ...

--- a/templates/sympa.conf.j2
+++ b/templates/sympa.conf.j2
@@ -283,7 +283,7 @@ parsed_family_files	{{ sympa_parsed_family_files }}
 ## db_type
 ## Type of the database (mysql|Pg|Oracle|Sybase|SQLite)
 ## Be careful to the case
-db_type	mysql
+db_type	{{ sympa_db_type }}
 
 ## db_name
 ## Name of the database


### PR DESCRIPTION
As previously discussed, this PR with PostgreSQL option for the sympa database. 

As initially in our code we install Postgres in the role itself, in order to act similarly for pgsql and mysql, I added a flag that gives the option to install the database package within the role itself or outside. And, by the way, I added some requirements checks. 

As far as tested, all the four options work, meaning that the role doesn't fail and let Sympa installed and running, with its database configured. However, as the role doesn't configure Apache with Sympa web interface, I couldn't fully test yet all functionalities. It would be good if you could test also. 

I will be working in the integration of Apache configuration for Sympa, with robots and other features. 

Also, it seems to me that the role still makes some assumptions about the host, particularly the presence of postfix or other sendmail-like MTA. I will be also working on it, as well as DKIM integration. 