### PR TITLE
chore(mysql_db): Ansible 2.10 compatibility for mysql_db

### DIFF
--- a/tasks/mysql.yml
+++ b/tasks/mysql.yml
@@ -38,7 +38,7 @@
     state: present
 
 - name: Create a new database with name '{{ sympa_db_name }}'
-  mysql_db:
+  community.mysql.mysql_db:
     name: "{{ sympa_db_name }}"
     encoding: utf8
 


### PR DESCRIPTION
Since Ansible 2.10, `mysql_db` is no longer a part of Ansible. It can be obtained from the Ansible Galaxy collection `community.mysql`. Note that this change probably breaks compatibility with Ansible <= 2.8.