### PR TITLE
Change task to install sympa from debian testing

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,18 @@
 ---
 ## Sympa configuration main tasks file
 
+- name: Add Debian testing repo
+  apt_repository:
+    repo: deb http://deb.debian.org/debian/ testing main
+
+- name: Pin Debian testing repo
+  copy:
+    content: |
+      Package: *
+      Pin: release a=testing
+      Pin-Priority: -1
+    dest: /etc/apt/preferences.d/limit-testing
+
 - name: Check that "debconf" and "debconf-utils" are installed
   apt:
     name:
@@ -59,6 +71,7 @@
       - sympa
       - fcgiwrap
     state: latest
+    default_release: testing
 
 - name: Fix permissions
   file:


### PR DESCRIPTION
This is neccesarry to get a sympa version >6.2.54.
This is neccessary to have this PR: https://github.com/sympa-community/sympa/issues/867
This is neccassary to prevent errors when using custom scenari with the [Sender] variable in a condition.
For example the uni_stuttgart_moderated scenario.