### PR TITLE
Also install pip3

### DIFF
--- a/tasks/mysql.yml
+++ b/tasks/mysql.yml
@@ -29,7 +29,9 @@
 
 - name: Install pip, if not yet installed
   apt: 
-    name: python-pip
+    name: 
+     - python-pip
+     - pyhton3-pip
     state: present
 
 - name: install mysqlclient pip module, if not yet installed


### PR DESCRIPTION
As the newer versions of the pip ansible module use pip3 instead of pip.