### PR TITLE
fix(install): Do not install python-pip but just python3-pip

### DIFF
--- a/tasks/mysql.yml
+++ b/tasks/mysql.yml
@@ -28,9 +28,8 @@
   when: sympa_install_db_package
 
 - name: Install pip, if not yet installed
-  apt: 
-    name: 
-     - python-pip
+  apt:
+    name:
      - python3-pip
     state: present
 


### PR DESCRIPTION
python-pip is no longer in the apt sources